### PR TITLE
The menu has cool background and we save on computer resource when loading file

### DIFF
--- a/resources/game_resources.qrc
+++ b/resources/game_resources.qrc
@@ -12,5 +12,8 @@
         <file>marjon_the_dragon.png</file>
         <file>grow.ogg</file>
         <file>shrink.ogg</file>
+        <file>276813041_drakkar__dragon__realistic__flying__paper__rock__scissors__RGB__3.png</file>
+        <file>868624477_three_dragons__RGB__flying__fantasy__realism__dark__cool.png</file>
+        <file>1977884409_three_dragons__RGB__flying__fantasy__realism__dark__cool.png</file>
     </qresource>
 </RCC>

--- a/src/game_resources.cpp
+++ b/src/game_resources.cpp
@@ -6,6 +6,16 @@
 game_resources::game_resources()
 {
   {
+    const QString filename{"276813041_drakkar__dragon__realistic__flying__paper__rock__scissors__RGB__3.png"};
+    QFile f(":/" + filename);
+    f.copy(filename);
+    if (!m_artwork_1.loadFromFile(filename.toStdString()))
+    {
+      QString msg{"Cannot find image file '" + filename + "'"};
+      throw std::runtime_error(msg.toStdString());
+    }
+  }
+  {
     const QString filename{"franjo.png"};
     QFile f(":/" + filename);
     f.copy(filename);
@@ -189,6 +199,7 @@ void test_game_resources()
   #ifndef NDEBUG // no tests in release
   game_resources g;
   assert(g.get_coastal_world().getSize().x > 0.0);
+  assert(g.get_artwork_1().getSize().x > 0.0);
 
   #endif
 }

--- a/src/game_resources.cpp
+++ b/src/game_resources.cpp
@@ -1,19 +1,14 @@
 #include "game_resources.h"
 
+#include <QResource>
 #include <QFile>
 #include <cassert>
 
 game_resources::game_resources()
 {
   {
-    const QString filename{"276813041_drakkar__dragon__realistic__flying__paper__rock__scissors__RGB__3.png"};
-    QFile f(":/" + filename);
-    f.copy(filename);
-    if (!m_artwork_1.loadFromFile(filename.toStdString()))
-    {
-      QString msg{"Cannot find image file '" + filename + "'"};
-      throw std::runtime_error(msg.toStdString());
-    }
+    QResource artWork1 { ":/276813041_drakkar__dragon__realistic__flying__paper__rock__scissors__RGB__3.png" };
+    m_artwork_1.loadFromMemory(artWork1.data(), artWork1.size());
   }
   {
     const QString filename{"franjo.png"};

--- a/src/game_resources.h
+++ b/src/game_resources.h
@@ -68,7 +68,7 @@ public:
 #endif // IS_ON_TRAVIS
 
 private:
-  /// Franjo
+  /// Franjo Weissing
   sf::Texture m_franjo;
 
   /// Dragon

--- a/src/game_resources.h
+++ b/src/game_resources.h
@@ -9,26 +9,29 @@ class game_resources
 public:
   game_resources();
 
-  /// Get the texture of a heterogenous landscape
-  sf::Texture &get_heterogenous_landscape() noexcept { return m_heterogenous_landscape; }
+  /// Get an artwork picture
+  sf::Texture& get_artwork_1() noexcept { return m_artwork_1; }
 
   /// Get the texture of a heterogenous landscape
-  sf::Texture &get_coastal_world() noexcept { return m_coastal_world; }
+  sf::Texture& get_heterogenous_landscape() noexcept { return m_heterogenous_landscape; }
 
   /// Get the texture of a heterogenous landscape
-  sf::Texture &get_grass_landscape() noexcept { return m_grass_landscape; }
+  sf::Texture& get_coastal_world() noexcept { return m_coastal_world; }
+
+  /// Get the texture of a heterogenous landscape
+  sf::Texture& get_grass_landscape() noexcept { return m_grass_landscape; }
 
   /// Get the texture of a the player
-  sf::Texture &get_player_sprite() noexcept { return m_player_sprite; }
+  sf::Texture& get_player_sprite() noexcept { return m_player_sprite; }
 
   /// Get a picture of a Marjon the dragon
-  sf::Texture &get_dragon() noexcept { return m_dragon; }
+  sf::Texture& get_dragon() noexcept { return m_dragon; }
 
   /// Get a picture of Franjo
-  sf::Texture &get_franjo() noexcept { return m_franjo; }
+  sf::Texture& get_franjo() noexcept { return m_franjo; }
 
   /// Get a picture of a Cat
-  sf::Texture &get_cat() noexcept { return m_cat; }
+  sf::Texture& get_cat() noexcept { return m_cat; }
 
   /// Get a font
   sf::Font &get_font() noexcept {return m_font; }
@@ -68,6 +71,9 @@ public:
 #endif // IS_ON_TRAVIS
 
 private:
+  /// Artwork 1
+  sf::Texture m_artwork_1;
+
   /// Franjo Weissing
   sf::Texture m_franjo;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,22 +159,22 @@ int main(int argc, char **argv) //!OCLINT tests may be long
   // Default view mode
   view_mode start_view = view_mode::game;
 
-  // Resolve arguments
-  if (args.size() > 1)
+  for (int i = 1; i != argc; ++i)
+  {
+    const std::string arg{argv[i]};
+    if (arg == "--menu")
     {
-      if (args[1] == "--menu")
-        {
-          start_view = view_mode::menu;
-        }
-      else if (args[1] == "--options")
-        {
-          start_view = view_mode::options;
-        }
-      else if (args[1] == "--no-sound")
-        {
-          music_off(options);
-        }
+      start_view = view_mode::menu;
     }
+    else if (arg == "--options")
+    {
+      start_view = view_mode::options;
+    }
+    else if (arg == "--no-sound")
+    {
+      music_off(options);
+    }
+  }
 
   view_manager v{start_view, options};
   v.exec();

--- a/src/menu_view.cpp
+++ b/src/menu_view.cpp
@@ -91,8 +91,8 @@ void menu_view::show()
   // Draw the background
   sf::Vector2f bg_dim(m_menu.get_height(), m_menu.get_height());
   sf::RectangleShape background_sprite(bg_dim);
+  background_sprite.setTexture(&m_game_resources.get_artwork_1());
   background_sprite.setPosition(10.0, 10.0);
-  background_sprite.setFillColor(sf::Color::Black);
   m_window.draw(background_sprite);
 
   // Draw buttons


### PR DESCRIPTION
We load file directly from memory without copying it. I would suggest refactor the whole resource handling like this.

```
    QResource artWork1 { ":/276813041_drakkar__dragon__realistic__flying__paper__rock__scissors__RGB__3.png" };
    m_artwork_1.loadFromMemory(artWork1.data(), artWork1.size());
```

Probably safe to load from memory according to [this](https://www.sfml-dev.org/documentation/2.5.1/classsf_1_1Texture.php#a2c4adb19dd4cbee0a588eeb85e52a249).