### PR TITLE
Re-expose #478, update test for #722

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -844,13 +844,15 @@ void test_game() //!OCLINT tests may be many
   }
 
   // (478) Saving a game and loading it, must result in the same game
+  #ifdef FIX_ISSUE_478
   {
     const game g;
     const std::string filename = "test.txt";
     save(g, filename); // To prevent a bloated/Winnebago class
-    //const game h = load(filename);
-    //assert(g == h);
+    const game h = load(filename);
+    assert(g == h);
   }
+  #endif // FIX_ISSUE_478
 
   #define FIX_ISSUE_524
   #ifdef FIX_ISSUE_524

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1239,27 +1239,28 @@ void test_game() //!OCLINT tests may be many
     assert(g.who_is_winning() == "2");
    }
 
+  //#define FIX_ISSUE_722
   #ifdef FIX_ISSUE_722
   // (722) In case of a tie, winner is decided on a coin flip
   {
       const int a_seed = 5;
-      const int another_seed = 6; // change if this picks the same winner
+      const int another_seed = 8; // change if this picks the same winner
 
       game a_game(game_options{a_seed});
       player &player_two = a_game.get_player(1);
       player_two.grow();
       player &player_three = a_game.get_player(2);
       player_three.grow();
-      assert(a_game.who_is_winning() != 0);
+      assert(a_game.who_is_winning() != "0");
 
       game another_game(game_options{another_seed});
       player &other_player_two = another_game.get_player(1);
       other_player_two.grow();
       player &other_player_three = another_game.get_player(2);
       other_player_three.grow();
-      assert(another_game.who_is_winning() != 0);
+      assert(another_game.who_is_winning() != "0");
 
-      assert(a_game.who_is_winning != another_game.who_is_winning());
+      assert(a_game.who_is_winning() != another_game.who_is_winning());
   }
   #endif // FIX_ISSUE_722
 


### PR DESCRIPTION
The test for #478 was only partially implemented, so I resurrected it. Although save-states may not be the most important now, I am happy they are part of a test.

The test for #722 was outdated, as a return type has changed from int to string, and the final test had a missing `()`.